### PR TITLE
make output of request to stdout optional

### DIFF
--- a/http/client.go
+++ b/http/client.go
@@ -27,6 +27,7 @@ type Client struct {
 	ntlm       *ntlmssp.Client
 	encryption bool
 	sendCBT    bool
+	Debug      bool
 }
 
 type teeReadCloser struct {
@@ -180,7 +181,9 @@ func (c *Client) Do(req *http.Request) (resp *http.Response, err error) {
 		req.Body = teeReadCloser{tr, req.Body}
 	}
 
-	fmt.Println(req)
+	if c.Debug {
+		fmt.Println(req)
+	}
 
 	resp, err = c.http.Do(req)
 	if err != nil {
@@ -223,7 +226,9 @@ func (c *Client) Do(req *http.Request) (resp *http.Response, err error) {
 			req.Body = ioutil.NopCloser(&body)
 		}
 
-		fmt.Println(req)
+		if c.Debug {
+			fmt.Println(req)
+		}
 
 		resp, err = c.http.Do(req)
 		if err != nil {


### PR DESCRIPTION
Thank you so much for this great library - I plan on using it for winrm and ntlm encrypted messages 

The following change is just to allow optional of request messages to the console